### PR TITLE
Specify package manager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"
   },
+  "packageManager": "yarn@1.22.22",
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@storybook/addon-a11y": "^9.0.0-rc.2",


### PR DESCRIPTION
This is helpful when the project is being used in a workspace where different package managers are involved.