### PR TITLE
Specify yarn version in engines instead of packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook"
   },
-  "packageManager": "yarn@1.22.22",
+  "engines":{
+    "yarn": "^1.22.22"
+  },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@storybook/addon-a11y": "^9.0.0-rc.2",


### PR DESCRIPTION
This is a follow-up to #9.

We have decided to use a different approach.

The problem with Corepack's packageManager field is that it doesn't allow for minor version updates, not even security fixes.