### PR TITLE
Workaround for docs theming issue

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,6 +2,7 @@ import type { Preview } from '@storybook/react-vite'
 import { withThemeByClassName } from '@storybook/addon-themes'
 // @ts-expect-error TS2307 - not a module
 import '../src/styles/global.css'
+import './storybook.css'
 
 const preview: Preview = {
   parameters: {

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -1,0 +1,5 @@
+/* https://github.com/storybookjs/storybook/issues/26242 */
+.docs-story {
+  background-color: var(--background);
+  color: var(--foreground);
+}


### PR DESCRIPTION
Make default docs examples a little more readable (dark theme issue). The simplest workaround I found for @storybook/addon-themes.


https://pr-30.oasis-ui.pages.dev/?path=/docs/components-accordion--docs
vs
https://oasis-ui.pages.dev/?path=/docs/components-accordion--docs