### PR TITLE
Add cursor pointer to buttons by default

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,4 +130,9 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  button:not([disabled]),
+  [role="button"]:not([disabled]) {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
As discussed in this issue Tailwindcss v4 removes the cursor pointer on buttons https://github.com/shadcn-ui/ui/issues/6843. So adding a global style that default to cursor pointer.