### PR TITLE
Input: add support for start and end decorations

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -52,21 +52,6 @@ function Input({
   const startStyle = !!startDecorationWidth ? { paddingLeft: `${16 + startDecorationWidth}px` } : {}
   const endStyle = !!endDecorationWidth ? { paddingRight: `${16 + endDecorationWidth}px` } : {}
 
-  const input = (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
-        className
-      )}
-      style={{ ...startStyle, ...endStyle }}
-      {...props}
-    />
-  )
-
   // const hasInsideDecorations = !!startDecoration || !!endDecoration
   // const hasOutsideDecorations = !!beforeStartDecoration || !!afterEndDecoration
   return (
@@ -78,7 +63,18 @@ function Input({
             {startDecoration}
           </span>
         )}
-        {input}
+        <input
+          type={type}
+          data-slot="input"
+          className={cn(
+            'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+            'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+            'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+            className
+          )}
+          style={{ ...startStyle, ...endStyle }}
+          {...props}
+        />
         {!!endDecoration && (
           <span className={'absolute right-2.5 top-2.5'} ref={endDecorationRef}>
             {endDecoration}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,9 +1,58 @@
 import * as React from 'react'
 
 import { cn } from '../../lib/utils'
+import { useEffect, useRef, useState } from 'react'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-  return (
+interface OwnProps {
+  // Something that needs to appear before the start, outside the field
+  beforeStartDecoration?: React.ReactNode
+
+  // Something that needs to appear at the start, inside the field
+  startDecoration?: React.ReactNode
+
+  // Something that needs to appear at the end, inside the field
+  endDecoration?: React.ReactNode
+
+  // Something that needs to appear after the end, outside the field
+  afterEndDecoration?: React.ReactNode
+}
+
+function Input({
+  className,
+  type,
+  beforeStartDecoration,
+  startDecoration,
+  endDecoration,
+  afterEndDecoration,
+  ...props
+}: React.ComponentProps<'input'> & OwnProps) {
+  const startDecorationRef = useRef<HTMLSpanElement>(null)
+  const [startDecorationWidth, setStartDecorationWidth] = useState<number>(0)
+  const endDecorationRef = useRef<HTMLSpanElement>(null)
+  const [endDecorationWidth, setEndDecorationWidth] = useState<number>(0)
+
+  useEffect(() => {
+    if (!!startDecoration && !!startDecorationRef.current) {
+      const rect = startDecorationRef.current.getBoundingClientRect()
+      setStartDecorationWidth(rect.width)
+    } else {
+      setStartDecorationWidth(0)
+    }
+  }, [startDecoration, startDecorationRef.current])
+
+  useEffect(() => {
+    if (!!endDecoration && !!endDecorationRef.current) {
+      const rect = endDecorationRef.current.getBoundingClientRect()
+      setEndDecorationWidth(rect.width)
+    } else {
+      setEndDecorationWidth(0)
+    }
+  }, [endDecoration, endDecorationRef.current]) // Re-run if content changes
+
+  const startStyle = !!startDecorationWidth ? { paddingLeft: `${16 + startDecorationWidth}px` } : {}
+  const endStyle = !!endDecorationWidth ? { paddingRight: `${16 + endDecorationWidth}px` } : {}
+
+  const input = (
     <input
       type={type}
       data-slot="input"
@@ -13,8 +62,31 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className
       )}
+      style={{ ...startStyle, ...endStyle }}
       {...props}
     />
+  )
+
+  // const hasInsideDecorations = !!startDecoration || !!endDecoration
+  // const hasOutsideDecorations = !!beforeStartDecoration || !!afterEndDecoration
+  return (
+    <>
+      {beforeStartDecoration}
+      <div className={'relative'}>
+        {!!startDecoration && (
+          <span className={'absolute left-2.5 top-2.5'} ref={startDecorationRef}>
+            {startDecoration}
+          </span>
+        )}
+        {input}
+        {!!endDecoration && (
+          <span className={'absolute right-2.5 top-2.5'} ref={endDecorationRef}>
+            {endDecoration}
+          </span>
+        )}
+      </div>
+      {afterEndDecoration}
+    </>
   )
 }
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -42,7 +42,7 @@ function Input({
     } else {
       setBeforeStartDecorationWidth(0)
     }
-  }, [beforeStartDecoration, beforeStartDecorationRef.current])
+  }, [beforeStartDecoration])
 
   useEffect(() => {
     if (!!startDecoration && !!startDecorationRef.current) {
@@ -51,7 +51,7 @@ function Input({
     } else {
       setStartDecorationWidth(0)
     }
-  }, [startDecoration, startDecorationRef.current])
+  }, [startDecoration])
 
   useEffect(() => {
     if (!!endDecoration && !!endDecorationRef.current) {
@@ -60,7 +60,7 @@ function Input({
     } else {
       setEndDecorationWidth(0)
     }
-  }, [endDecoration, endDecorationRef.current]) // Re-run if content changes
+  }, [endDecoration])
 
   useEffect(() => {
     if (!!afterEndDecoration && !!afterEndDecorationRef.current) {
@@ -69,7 +69,7 @@ function Input({
     } else {
       setAfterEndDecorationWidth(0)
     }
-  }, [afterEndDecoration, afterEndDecorationRef.current]) // Re-run if content changes
+  }, [afterEndDecoration])
 
   const startDecoratorStyle = beforeStartDecorationWidth
     ? { paddingLeft: `${8 + beforeStartDecorationWidth}px` }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -26,10 +26,23 @@ function Input({
   afterEndDecoration,
   ...props
 }: React.ComponentProps<'input'> & OwnProps) {
+  const beforeStartDecorationRef = useRef<HTMLSpanElement>(null)
+  const [beforeStartDecorationWidth, setBeforeStartDecorationWidth] = useState<number>(0)
   const startDecorationRef = useRef<HTMLSpanElement>(null)
   const [startDecorationWidth, setStartDecorationWidth] = useState<number>(0)
   const endDecorationRef = useRef<HTMLSpanElement>(null)
   const [endDecorationWidth, setEndDecorationWidth] = useState<number>(0)
+  const afterEndDecorationRef = useRef<HTMLSpanElement>(null)
+  const [afterEndDecorationWidth, setAfterEndDecorationWidth] = useState<number>(0)
+
+  useEffect(() => {
+    if (!!beforeStartDecoration && !!beforeStartDecorationRef.current) {
+      const rect = beforeStartDecorationRef.current.getBoundingClientRect()
+      setBeforeStartDecorationWidth(rect.width)
+    } else {
+      setBeforeStartDecorationWidth(0)
+    }
+  }, [beforeStartDecoration, beforeStartDecorationRef.current])
 
   useEffect(() => {
     if (!!startDecoration && !!startDecorationRef.current) {
@@ -49,17 +62,47 @@ function Input({
     }
   }, [endDecoration, endDecorationRef.current]) // Re-run if content changes
 
-  const startStyle = !!startDecorationWidth ? { paddingLeft: `${16 + startDecorationWidth}px` } : {}
-  const endStyle = !!endDecorationWidth ? { paddingRight: `${16 + endDecorationWidth}px` } : {}
+  useEffect(() => {
+    if (!!afterEndDecoration && !!afterEndDecorationRef.current) {
+      const rect = afterEndDecorationRef.current.getBoundingClientRect()
+      setAfterEndDecorationWidth(rect.width)
+    } else {
+      setAfterEndDecorationWidth(0)
+    }
+  }, [afterEndDecoration, afterEndDecorationRef.current]) // Re-run if content changes
 
-  // const hasInsideDecorations = !!startDecoration || !!endDecoration
-  // const hasOutsideDecorations = !!beforeStartDecoration || !!afterEndDecoration
+  const startDecoratorStyle = beforeStartDecorationWidth
+    ? { paddingLeft: `${8 + beforeStartDecorationWidth}px` }
+    : {}
+
+  const startStyle =
+    !!startDecorationWidth || beforeStartDecorationWidth
+      ? { paddingLeft: `${16 + beforeStartDecorationWidth + startDecorationWidth}px` }
+      : {}
+
+  const endStyle =
+    !!endDecorationWidth || !afterEndDecorationWidth
+      ? { paddingRight: `${16 + endDecorationWidth + afterEndDecorationWidth}px` }
+      : {}
+
+  const endDecoratorStyle = afterEndDecorationWidth
+    ? { paddingRight: `${8 + afterEndDecorationWidth}px` }
+    : {}
+
   return (
     <>
-      {beforeStartDecoration}
       <div className={'relative'}>
+        {!!beforeStartDecoration && (
+          <span
+            className={'absolute left-2.5 top-2.5 pr-2.5'}
+            style={{ borderRight: '2px solid black' }}
+            ref={beforeStartDecorationRef}
+          >
+            {beforeStartDecoration}
+          </span>
+        )}
         {!!startDecoration && (
-          <span className={'absolute left-2.5 top-2.5'} ref={startDecorationRef}>
+          <span className={'absolute left-2.5 top-2.5'} style={startDecoratorStyle} ref={startDecorationRef}>
             {startDecoration}
           </span>
         )}
@@ -76,12 +119,20 @@ function Input({
           {...props}
         />
         {!!endDecoration && (
-          <span className={'absolute right-2.5 top-2.5'} ref={endDecorationRef}>
+          <span className={'absolute right-2.5 top-2.5'} style={endDecoratorStyle} ref={endDecorationRef}>
             {endDecoration}
           </span>
         )}
+        {!!afterEndDecoration && (
+          <span
+            className={'absolute right-2.5 top-2.5 pl-2.5'}
+            style={{ borderLeft: '2px solid black' }}
+            ref={afterEndDecorationRef}
+          >
+            {afterEndDecoration}
+          </span>
+        )}
       </div>
-      {afterEndDecoration}
     </>
   )
 }

--- a/src/stories/Input/Input.stories.tsx
+++ b/src/stories/Input/Input.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Input } from '../../components'
 import { Label } from '../../components'
 import { expect, within, userEvent } from 'storybook/test'
-import { SearchIcon, X as CloseIcon } from 'lucide-react'
+import { Rocket as LaunchIcon, Settings as SettingsIcon } from 'lucide-react'
 import { SearchInput as SearchInputCmp } from '../../components/input'
 import { useState } from 'react'
 
@@ -51,8 +51,8 @@ export const Default: Story = {
 export const WithManualIcon: Story = {
   render: () => (
     <div className="relative w-[300px]">
-      <SearchIcon className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-      <Input type="search" placeholder="Search..." className="pl-8" />
+      <SettingsIcon className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+      <Input placeholder="Search..." className="pl-8" />
     </div>
   ),
 }
@@ -61,10 +61,9 @@ export const WithStartAndEndDecoration: Story = {
   render: () => (
     <div className="w-[300px]">
       <Input
-        type="search"
         placeholder="Search..."
-        startDecoration={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
-        endDecoration={<CloseIcon className="h-4 w-4 text-muted-foreground" />}
+        startDecoration={<SettingsIcon className="h-4 w-4 text-muted-foreground" />}
+        endDecoration={<LaunchIcon className="h-4 w-4 text-muted-foreground" />}
       />
     </div>
   ),

--- a/src/stories/Input/Input.stories.tsx
+++ b/src/stories/Input/Input.stories.tsx
@@ -57,13 +57,39 @@ export const WithManualIcon: Story = {
   ),
 }
 
-export const WithStartAndEndDecoration: Story = {
+export const WithInternalStartAndEndDecoration: Story = {
   render: () => (
     <div className="w-[300px]">
       <Input
         placeholder="Search..."
         startDecoration={<SettingsIcon className="h-4 w-4 text-muted-foreground" />}
         endDecoration={<LaunchIcon className="h-4 w-4 text-muted-foreground" />}
+      />
+    </div>
+  ),
+}
+
+export const WithExternalStartAndEndDecoration: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Input
+        placeholder="Search..."
+        beforeStartDecoration={<SettingsIcon className="h-4 w-4 text-muted-foreground" />}
+        afterEndDecoration={<LaunchIcon className="h-4 w-4 text-muted-foreground" />}
+      />
+    </div>
+  ),
+}
+
+export const WithDoubleStartAndEndDecoration: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Input
+        placeholder="Search..."
+        beforeStartDecoration={<SettingsIcon className="h-4 w-4 text-muted-foreground" />}
+        startDecoration={<SettingsIcon className="h-4 w-4" />}
+        endDecoration={<LaunchIcon className="h-4 w-4" />}
+        afterEndDecoration={<LaunchIcon className="h-4 w-4 text-muted-foreground" />}
       />
     </div>
   ),

--- a/src/stories/Input/Input.stories.tsx
+++ b/src/stories/Input/Input.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Input } from '../../components'
 import { Label } from '../../components'
 import { expect, within, userEvent } from 'storybook/test'
-import { SearchIcon } from 'lucide-react'
+import { SearchIcon, X as CloseIcon } from 'lucide-react'
 import { SearchInput as SearchInputCmp } from '../../components/input'
 import { useState } from 'react'
 
@@ -48,11 +48,24 @@ export const Default: Story = {
   },
 }
 
-export const WithIcon: Story = {
+export const WithManualIcon: Story = {
   render: () => (
     <div className="relative w-[300px]">
       <SearchIcon className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
       <Input type="search" placeholder="Search..." className="pl-8" />
+    </div>
+  ),
+}
+
+export const WithStartAndEndDecoration: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Input
+        type="search"
+        placeholder="Search..."
+        startDecoration={<SearchIcon className="h-4 w-4 text-muted-foreground" />}
+        endDecoration={<CloseIcon className="h-4 w-4 text-muted-foreground" />}
+      />
     </div>
   ),
 }


### PR DESCRIPTION
(This PR is implemented on top of #100 and #101, so only the last few commits belong to this change.)

``` TypsScript
<Input
    placeholder="Search..."
    beforeStartDecoration={<SettingsIcon className="h-4 w-4 text-muted-foreground" />}
    startDecoration={<SettingsIcon className="h-4 w-4" />}
    endDecoration={<LaunchIcon className="h-4 w-4" />}
    afterEndDecoration={<LaunchIcon className="h-4 w-4 text-muted-foreground" />}
/>
```

Now gets us:

<img width="323" height="62" alt="image" src="https://github.com/user-attachments/assets/934f93f5-1098-4240-85d4-377e113d9a4d" />

(We can adjust the exact style for the separator when we have agreement on the working of the code.)

This is required for the designs like this:

<img width="336" height="73" alt="image" src="https://github.com/user-attachments/assets/79ca8881-f769-46a7-82d8-a3e05a3c82d4" />

