### PR TITLE
Add wrapper to render data correctly within tooltip content

### DIFF
--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -23,7 +23,7 @@ const TooltipContentNoArrow = ({
       sideOffset={sideOffset}
       {...props}
     >
-      {children}
+      <div className="inline-block">{children}</div>
     </TooltipContent>
   )
 }


### PR DESCRIPTION
Fix issue with rendering more complex tooltips. Needed for https://github.com/oasisprotocol/explorer/pull/2299

<img width="270" height="127" alt="Screenshot from 2025-10-31 11-46-32" src="https://github.com/user-attachments/assets/2770c122-7dab-4965-9634-7a6ecb3256ca" />
vs 
<img width="338" height="113" alt="Screenshot from 2025-10-31 11-52-03" src="https://github.com/user-attachments/assets/4896f726-8fff-4285-ba08-99a376ccd252" />

<img width="338" height="113" alt="Screenshot from 2025-10-31 11-46-40" src="https://github.com/user-attachments/assets/51a37731-8b1d-45a8-9174-543b496957f9" />
vs
<img width="338" height="113" alt="Screenshot from 2025-10-31 11-52-10" src="https://github.com/user-attachments/assets/529fefc7-4c98-4efd-83f5-b282e5206305" />


