### PR TITLE
Update vite config for node 22

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'node:path'
 import { defineConfig, UserConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import pkg from './package.json' assert { type: 'json' }
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
   base: './',


### PR DESCRIPTION
There used to be a warning, when running storybook:

> ▲ [WARNING] The "assert" keyword is not supported in the configured target environment  ("node22.21.1") [assert-to-with]

This changes fixes that.